### PR TITLE
Add unit test for lut RTL

### DIFF
--- a/lassen/lut.py
+++ b/lassen/lut.py
@@ -12,10 +12,10 @@ def gen_lut(family):
     Bit = family.Bit
 
     # Implement a 3-bit LUT
-    def lut(lut: LUT, bit0: Bit, bit1: Bit, bit2: Bit) -> Bit:
+    def _lut(lut: LUT, bit0: Bit, bit1: Bit, bit2: Bit) -> Bit:
         i = _IDX_t([bit0, bit1, bit2])
         i = i.zext(5)
         return ((lut >> i) & 1)[0]
     if family.Bit is m.Bit:
-        lut = m.circuit.combinational(lut)
-    return lut
+        _lut = m.circuit.combinational(_lut)
+    return _lut


### PR DESCRIPTION
@Kuree had a question about the semantics of the LUT implementation, I wrote this simple unit test for the RTL to verify what the current behavior is.

The print out is (for lut code `0xEE`):
```
bit0, bit1, bit2,    O
   0     0     0     0
   1     0     0     1
   0     1     0     1
   1     1     0     1
   0     0     1     0
   1     0     1     1
   0     1     1     1
   1     1     1     1
```

I had to change the name of `lut` to `_lut` because otherwise verilator complained when compiling:
```
%Error: lut.v:38: Unsupported in C: Variable has same name as cell: lut
%Error: lut.v:38: Unsupported in C: Variable has same name as CELLINLINE 'lut': lut
%Error: Exiting due to 2 error(s), 1 warning(s)
```
 (I think because there's an input named the same as the top module name)

@rdaly525 can you confirm that this is the intended semantics for the LUT (specifically, the endianness w.r.t. the lut code and the select bits)? Mainly, does this match what coreir expects?