### PR TITLE
add rtl tests to all pe tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ install:
 - git clone https://github.com/phanrahan/peak.git
 - git clone -b iofix https://github.com/rdaly525/MetaMapper.git
 - pip install --ignore-installed git+git://github.com/leonardt/fault#egg=fault
-- git clone https://github.com/rdaly525/MetaMapper.git
 - pip install -e ./peak
 - pip install -e ./MetaMapper
 - pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ install:
 - pip install -e ./MetaMapper
 - pip install -e .
 script:
-- pytest -x tests/
+- pytest -v tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 - pip install pytest-cov
 - git clone https://github.com/phanrahan/peak.git
 - git clone -b iofix https://github.com/rdaly525/MetaMapper.git
-- pip install --ignore-installed git+git://github.com/leonardt/fault@patch-pipefail#egg=fault
+- pip install --ignore-installed git+git://github.com/leonardt/fault#egg=fault
 - pip install --ignore-installed git+git://github.com/phanrahan/magma#egg=magma-lang
 - pip install -e ./peak
 - pip install -e ./MetaMapper

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
 - pip install pytest-cov
 - git clone https://github.com/phanrahan/peak.git
 - git clone -b iofix https://github.com/rdaly525/MetaMapper.git
-- pip install --ignore-installed git+git://github.com/leonardt/fault#egg=fault
+- pip install --ignore-installed git+git://github.com/leonardt/fault@patch-pipefail#egg=fault
 - pip install --ignore-installed git+git://github.com/phanrahan/magma#egg=magma-lang
 - pip install -e ./peak
 - pip install -e ./MetaMapper

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: python
 addons:
   apt:
-    sources:
-    - ubuntu-toolchain-r-test
     packages:
-    - g++-4.9
-    - verilator    
+    - verilator
 before_install:
 # install conda
 - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/lassen/sim.py
+++ b/lassen/sim.py
@@ -52,12 +52,14 @@ def gen_alu(family: TypeFamily, datawidth, assembler=None):
             gte_pred = a >= b
             lte_pred = a <= b
             abs_pred = a >= 0
+            shr = a >> b
         elif signed == Signed.unsigned:
             mula, mulb = a.zext(16), b.zext(16)
             mul = mula * mulb
             gte_pred = a >= b
             lte_pred = a <= b
             abs_pred = a >= 0
+            shr = a >> b
 
         #Negate B and add cin if subtract
         Cin = Bit(0)
@@ -98,7 +100,7 @@ def gen_alu(family: TypeFamily, datawidth, assembler=None):
             res, res_p = a ^ b, Bit(0)
         elif alu == ALU.SHR:
             #res, res_p = a >> Data(b[:4]), Bit(0)
-            res, res_p = a >> b, Bit(0)
+            res, res_p = shr, Bit(0)
         elif alu == ALU.SHL:
             #res, res_p = a << Data(b[:4]), Bit(0)
             res, res_p = a << b, Bit(0)

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -9,161 +9,141 @@ import pytest
 Bit = Bit
 Data = BitVector[DATAWIDTH]
 
-op = namedtuple("op", ["name", "func"])
+pe = gen_pe(BitVector.get_family())()
+
+op = namedtuple("op", ["inst", "func"])
 NTESTS = 16
 
-@pytest.mark.parametrize("op", [
-    op('and_', lambda x, y: x&y),
-    op('or_',  lambda x, y: x|y),
-    op('xor',  lambda x, y: x^y),
-    op('add',  lambda x, y: x+y),
-    op('sub',  lambda x, y: x-y),
-    op('lsl',  lambda x, y: x << y),
-    op('lsr',  lambda x, y: x >> y),
-    op('umin',  lambda x, y: (x < y).ite(x, y)),
-    op('umax',  lambda x, y: (x > y).ite(x, y))
-])
-def test_unsigned_binary(op):
-    pe = gen_pe(BitVector.get_family())()
-    inst = getattr(asm, op.name)()
-    for _ in range(NTESTS):
-        x = UIntVector.random(DATAWIDTH)
-        y = UIntVector.random(DATAWIDTH)
-        res, _, _ = pe(inst, Data(x), Data(y))
-        assert res==op.func(x,y)
+def bfloat16(sign, exponent, mantissa):
+    sign &= 0x1
+    exponent &= 0xff
+    mantissa &= 0x7f
+    return Data((sign << 15) | (exponent << 7) | mantissa)
+
 
 @pytest.mark.parametrize("op", [
-    op('asr',  lambda x, y: x >> y),
-    op('smin',  lambda x, y: (x < y).ite(x, y)),
-    op('smax',  lambda x, y: (x > y).ite(x, y)),
+    op(asm.and_(),  lambda x, y: x&y),
+    op(asm.or_(),   lambda x, y: x|y),
+    op(asm.xor(),   lambda x, y: x^y),
+    op(asm.add(),   lambda x, y: x+y),
+    op(asm.sub(),   lambda x, y: x-y),
+    op(asm.lsl(),   lambda x, y: x << y),
+    op(asm.lsr(),   lambda x, y: x >> y),
+    op(asm.umin(),  lambda x, y: (x < y).ite(x, y)),
+    op(asm.umax(),  lambda x, y: (x > y).ite(x, y))
 ])
-def test_signed_binary(op):
-    pe = gen_pe(BitVector.get_family())()
-    inst = getattr(asm, op.name)()
-    for _ in range(NTESTS):
-        x = SIntVector.random(DATAWIDTH)
-        y = SIntVector.random(DATAWIDTH)
-        res, _, _ = pe(inst, Data(x), Data(y))
-        assert res==op.func(x,y)
+@pytest.mark.parametrize("args", [
+    (UIntVector.random(DATAWIDTH), UIntVector.random(DATAWIDTH))  
+        for _ in range(NTESTS) ] )
+def test_unsigned_binary(op, args):
+    x, y = args
+    res, _, _ = pe(op.inst, Data(x), Data(y))
+    assert res==op.func(x,y)
 
 @pytest.mark.parametrize("op", [
-    op('abs',  lambda x: x if x > 0 else -x),
+    op(asm.lsl(),   lambda x, y: x << y),
+    op(asm.asr(),   lambda x, y: x >> y),
+    op(asm.smin(),  lambda x, y: (x < y).ite(x, y)),
+    op(asm.smax(),  lambda x, y: (x > y).ite(x, y)),
 ])
-def test_signed_unary(op):
-    pe = gen_pe(BitVector.get_family())()
-    inst = getattr(asm, op.name)()
-    for _ in range(NTESTS):
-        x = SIntVector.random(DATAWIDTH)
-        res, _, _ = pe(inst, Data(x))
-        assert res == op.func(x)
+@pytest.mark.parametrize("args", [
+    (SIntVector.random(DATAWIDTH), SIntVector.random(DATAWIDTH))  
+        for _ in range(NTESTS) ] )
+def test_signed_binary(op, args):
+    x, y = args
+    res, _, _ = pe(op.inst, Data(x), Data(y))
+    assert res==op.func(x,y)
 
 @pytest.mark.parametrize("op", [
-    op('eq',   lambda x, y: x == y),
-    op('ne',   lambda x, y: x != y),
-    op('ugt',  lambda x, y: x >  y),
-    op('uge',  lambda x, y: x >= y),
-    op('ult',  lambda x, y: x <  y),
-    op('ule',  lambda x, y: x <= y),
+    op(asm.abs(),  lambda x: x if x > 0 else -x),
 ])
-def test_unsigned_relation(op):
-    pe = gen_pe(BitVector.get_family())()
-    inst = getattr(asm, op.name)()
-    for _ in range(NTESTS):
-        x = UIntVector.random(DATAWIDTH)
-        y = UIntVector.random(DATAWIDTH)
-        _, res_p, _ = pe(inst, Data(x), Data(y))
-        assert res_p==op.func(x,y)
+@pytest.mark.parametrize("args", 
+    [SIntVector.random(DATAWIDTH) for _ in range(NTESTS) ] )
+def test_signed_unary(op, args):
+    x = args
+    res, _, _ = pe(op.inst, Data(x))
+    assert res == op.func(x)
 
 @pytest.mark.parametrize("op", [
-    op('sgt',  lambda x, y: x >  y),
-    op('sge',  lambda x, y: x >= y),
-    op('slt',  lambda x, y: x <  y),
-    op('sle',  lambda x, y: x <= y),
+    op(asm.eq(),   lambda x, y: x == y),
+    op(asm.ne(),   lambda x, y: x != y),
+    op(asm.ugt(),  lambda x, y: x >  y),
+    op(asm.uge(),  lambda x, y: x >= y),
+    op(asm.ult(),  lambda x, y: x <  y),
+    op(asm.ule(),  lambda x, y: x <= y),
 ])
-def test_signed_relation(op):
-    pe = gen_pe(BitVector.get_family())()
-    inst = getattr(asm, op.name)()
-    for _ in range(NTESTS):
-        x = SIntVector.random(DATAWIDTH)
-        y = SIntVector.random(DATAWIDTH)
-        _, res_p, _ = pe(inst, Data(x), Data(y))
-        assert res_p==op.func(x,y)
+@pytest.mark.parametrize("args", [
+    (UIntVector.random(DATAWIDTH), UIntVector.random(DATAWIDTH))  
+        for _ in range(NTESTS) ] )
+def test_unsigned_relation(op, args):
+    x, y = args
+    _, res_p, _ = pe(op.inst, Data(x), Data(y))
+    assert res_p==op.func(x,y)
 
-def test_sel():
-    pe = gen_pe(BitVector.get_family())()
+@pytest.mark.parametrize("op", [
+    op(asm.sgt(),  lambda x, y: x >  y),
+    op(asm.sge(),  lambda x, y: x >= y),
+    op(asm.slt(),  lambda x, y: x <  y),
+    op(asm.sle(),  lambda x, y: x <= y),
+])
+@pytest.mark.parametrize("args", [
+    (SIntVector.random(DATAWIDTH), SIntVector.random(DATAWIDTH))  
+        for _ in range(NTESTS) ] )
+def test_signed_relation(op, args):
+    x, y = args
+    _, res_p, _ = pe(op.inst, Data(x), Data(y))
+    assert res_p==op.func(x,y)
+
+@pytest.mark.parametrize("args", [
+    (UIntVector.random(DATAWIDTH), UIntVector.random(DATAWIDTH))  
+        for _ in range(NTESTS) ] )
+def test_sel(args):
     inst = asm.sel()
-    for _ in range(NTESTS):
-        x = UIntVector.random(DATAWIDTH)
-        y = UIntVector.random(DATAWIDTH)
-        res, _, _ = pe(inst, Data(x), Data(y), Bit(0))
-        assert res==y
-        res, _, _ = pe(inst, Data(x), Data(y), Bit(1))
-        assert res==x
+    x, y = args
+    res, _, _ = pe(inst, Data(x), Data(y), Bit(0))
+    assert res==y
+    res, _, _ = pe(inst, Data(x), Data(y), Bit(1))
+    assert res==x
 
-def test_smult():
+@pytest.mark.parametrize("args", [
+    (SIntVector.random(DATAWIDTH), SIntVector.random(DATAWIDTH))  
+        for _ in range(NTESTS) ] )
+def test_smult(args):
     def mul(x,y):
         mulx, muly = x.sext(DATAWIDTH), y.sext(DATAWIDTH)
         return mulx * muly
-    pe = gen_pe(BitVector.get_family())()
     smult0 = asm.smult0()
     smult1 = asm.smult1()
     smult2 = asm.smult2()
-    for _ in range(NTESTS):
-        x = SIntVector.random(DATAWIDTH)
-        y = SIntVector.random(DATAWIDTH)
-        xy = mul(x,y)
-        res, _, _ = pe(smult0, Data(x), Data(y))
-        assert res == xy[0:DATAWIDTH]
-        res, _, _ = pe(smult1, Data(x), Data(y))
-        assert res == xy[DATAWIDTH//2:DATAWIDTH//2+DATAWIDTH]
-        res, _, _ = pe(smult2, Data(x), Data(y))
-        assert res == xy[DATAWIDTH:]
+    x, y = args
+    xy = mul(x,y)
+    res, _, _ = pe(smult0, Data(x), Data(y))
+    assert res == xy[0:DATAWIDTH]
+    res, _, _ = pe(smult1, Data(x), Data(y))
+    assert res == xy[DATAWIDTH//2:DATAWIDTH//2+DATAWIDTH]
+    res, _, _ = pe(smult2, Data(x), Data(y))
+    assert res == xy[DATAWIDTH:]
 
-def test_umult():
+@pytest.mark.parametrize("args", [
+    (UIntVector.random(DATAWIDTH), UIntVector.random(DATAWIDTH))  
+        for _ in range(NTESTS) ] )
+def test_umult(args):
     def mul(x,y):
         mulx, muly = x.zext(DATAWIDTH), y.zext(DATAWIDTH)
         return mulx * muly
-    pe = gen_pe(BitVector.get_family())()
     umult0 = asm.umult0()
     umult1 = asm.umult1()
     umult2 = asm.umult2()
-    for _ in range(NTESTS):
-        x = UIntVector.random(DATAWIDTH)
-        y = UIntVector.random(DATAWIDTH)
-        xy = mul(x,y)
-        res, _, _ = pe(umult0, Data(x), Data(y))
-        assert res == xy[0:DATAWIDTH]
-        res, _, _ = pe(umult1, Data(x), Data(y))
-        assert res == xy[DATAWIDTH//2:DATAWIDTH//2+DATAWIDTH]
-        res, _, _ = pe(umult2, Data(x), Data(y))
-        assert res == xy[DATAWIDTH:]
+    x, y = args
+    xy = mul(x,y)
+    res, _, _ = pe(umult0, Data(x), Data(y))
+    assert res == xy[0:DATAWIDTH]
+    res, _, _ = pe(umult1, Data(x), Data(y))
+    assert res == xy[DATAWIDTH//2:DATAWIDTH//2+DATAWIDTH]
+    res, _, _ = pe(umult2, Data(x), Data(y))
+    assert res == xy[DATAWIDTH:]
 
 
-def test_fp_add():
-    pe = gen_pe(BitVector.get_family())()
-    inst = asm.fp_add()
-    # [sign, exponent (decimal), mantissa (binary)]:
-    # a   = [0, -111, 1.0000001]
-    # b   = [0, -112, 1.0000010]
-    # res = [0, -111, 1.1000010]
-    res, res_p, irq = pe(inst, Data(0x801),Data(0x782))
-    assert res==0x842
-    assert res_p==0
-    assert irq==0
-
-def test_fp_mult():
-    pe = gen_pe(BitVector.get_family())()
-    inst = asm.fp_mult()
-    # [sign, exponent (decimal), mantissa (binary)]:
-    # a   = [0, 2, 1.0000000]
-    # b   = [0, 1, 1.0000001]
-    # res = [0, 3, 1.0000001]
-    # mant = mant(a) * mant(b)
-    # exp = exp(a) + exp(b)
-    res, res_p, irq = pe(inst, Data(0x4080),Data(0x4001))
-    assert res==0x4101
-    assert res_p==0
-    assert irq==0
 
 
 #TODO these tests are likely captured by the tests above. Keep them for now
@@ -317,23 +297,43 @@ def test_slt():
     res, res_p, irq = pe(inst,Data(1),Data(1))
     assert res_p==0
 
+#
+# floating point
+#
+
+def test_fp_add():
+    inst = asm.fp_add()
+    # [sign, exponent (decimal), mantissa (binary)]:
+    # a   = [0, -111, 1.0000001]
+    # b   = [0, -112, 1.0000010]
+    # res = [0, -111, 1.1000010]
+    res, res_p, irq = pe(inst, Data(0x801),Data(0x782))
+    assert res==0x842
+    assert res_p==0
+    assert irq==0
+
+def test_fp_mult():
+    inst = asm.fp_mult()
+    # [sign, exponent (decimal), mantissa (binary)]:
+    # a   = [0, 2, 1.0000000]
+    # b   = [0, 1, 1.0000001]
+    # res = [0, 3, 1.0000001]
+    # mant = mant(a) * mant(b)
+    # exp = exp(a) + exp(b)
+    res, res_p, irq = pe(inst, Data(0x4080),Data(0x4001))
+    assert res==0x4101
+    assert res_p==0
+    assert irq==0
+
 def test_get_mant():
-    # instantiate an PE - calls PE.__init__
-    pe = gen_pe(BitVector.get_family())()
-    # format an 'and' instruction
     inst = asm.fgetmant()
-    # execute PE instruction with the arguments as inputs -  call PE.__call__
     res, res_p, irq = pe(inst, Data(0x7F8A), Data(0x0000))
     assert res==0xA
     assert res_p==0
     assert irq==0
 
 def test_add_exp_imm():
-    # instantiate an PE - calls PE.__init__
-    pe = gen_pe(BitVector.get_family())()
-    # format an 'and' instruction
     inst = asm.faddiexp()
-    # execute PE instruction with the arguments as inputs -  call PE.__call__
     res, res_p, irq = pe(inst, Data(0x7F8A), Data(0x0005))
     # 7F8A => Sign=0; Exp=0xFF; Mant=0x0A
     # Add 5 to exp => Sign=0; Exp=0x04; Mant=0x0A i.e. float  = 0x020A
@@ -342,11 +342,7 @@ def test_add_exp_imm():
     assert irq==0
 
 def test_sub_exp():
-    # instantiate an PE - calls PE.__init__
-    pe = gen_pe(BitVector.get_family())()
-    # format an 'and' instruction
     inst = asm.fsubexp()
-    # execute PE instruction with the arguments as inputs -  call PE.__call__
     res, res_p, irq = pe(inst, Data(0x7F8A), Data(0x4005))
     # 7F8A => Sign=0; Exp=0xFF; Mant=0x0A
     # 4005 => Sign=0; Exp=0x80; Mant=0x05 (0100 0000 0000 0101)
@@ -356,11 +352,7 @@ def test_sub_exp():
     assert irq==0
 
 def test_cnvt_exp_to_float():
-    # instantiate an PE - calls PE.__init__
-    pe = gen_pe(BitVector.get_family())()
-    # format an 'and' instruction
     inst = asm.fcnvexp2f()
-    # execute PE instruction with the arguments as inputs -  call PE.__call__
     res, res_p, irq = pe(inst, Data(0x4005), Data(0x0000))
     # 4005 => Sign=0; Exp=0x80; Mant=0x05 (0100 0000 0000 0101) i.e. unbiased exp = 1
     # res: 3F80 => Sign=0; Exp=0x7F; Mant=0x00 (0011 1111 1000 0000)
@@ -369,11 +361,7 @@ def test_cnvt_exp_to_float():
     assert irq==0
 
 def test_get_float_int():
-    # instantiate an PE - calls PE.__init__
-    pe = gen_pe(BitVector.get_family())()
-    # format an 'and' instruction
     inst = asm.fgetfint()
-    # execute PE instruction with the arguments as inputs -  call PE.__call__
     res, res_p, irq = pe(inst, Data(0x4020), Data(0x0000))
     #2.5 = 10.1 i.e. exp = 1 with 1.01 # biased exp = 128 i.e 80
     #float is 0100 0000 0010 0000 i.e. 4020
@@ -383,11 +371,7 @@ def test_get_float_int():
     assert irq==0
 
 def test_get_float_frac():
-    # instantiate an PE - calls PE.__init__
-    pe = gen_pe(BitVector.get_family())()
-    # format an 'and' instruction
     inst = asm.fgetffrac()
-    # execute PE instruction with the arguments as inputs -  call PE.__call__
     res, res_p, irq = pe(inst, Data(0x4020), Data(0x0000))
     #2.5 = 10.1 i.e. exp = 1 with 1.01 # biased exp = 128 i.e 80
     #float is 0100 0000 0010 0000 i.e. 4020
@@ -395,3 +379,4 @@ def test_get_float_frac():
     assert res==0x80
     assert res_p==0
     assert irq==0
+

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -38,7 +38,10 @@ magma.compile(f"{test_dir}/WrappedPE", pe_circuit, output="coreir-verilog")
 
 def rtl_tester(test_op, data0, data1, bit0=None, res=None, res_p=None):
     tester.clear()
-    tester.circuit.inst = assembler(test_op.inst)
+    if hasattr(test_op, "inst"):
+        tester.circuit.inst = assembler(test_op.inst)
+    else:
+        tester.circuit.inst = assembler(test_op)
     tester.circuit.CLK = 0
     data0 = BitVector[16](data0)
     data1 = BitVector[16](data1)

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -1,18 +1,69 @@
 from collections import namedtuple
-import operator
 import lassen.asm as asm
 from lassen.sim import gen_pe
 from lassen.isa import DATAWIDTH
 from hwtypes import SIntVector, UIntVector, BitVector, Bit
 import pytest
+import magma
+import peak
+import fault
+import os
+from peak.auto_assembler import generate_assembler
+
+
+class HashableDict(dict):
+    def __hash__(self):
+        return hash(tuple(sorted(self.keys())))
+
 
 Bit = Bit
 Data = BitVector[DATAWIDTH]
 
-pe = gen_pe(BitVector.get_family())()
+pe_ = gen_pe(BitVector.get_family())
+pe = pe_()
+
+# create these variables in global space so that we can reuse them easily
+pe_magma = gen_pe(magma.get_family())
+instr_name, inst_type = pe.__call__._peak_isa_
+assembler, disassembler, width, layout = \
+            generate_assembler(inst_type)
+instr_magma_type = type(pe_magma.interface.ports[instr_name])
+pe_circuit = peak.wrap_with_disassembler(pe_magma, disassembler, width,
+                                         HashableDict(layout),
+                                         instr_magma_type)
+tester = fault.Tester(pe_circuit, clock=pe_circuit.CLK)
+test_dir = "tests/build"
+magma.compile(f"{test_dir}/WrappedPE", pe_circuit, output="coreir-verilog")
+
+
+def rtl_tester(test_op, data0, data1, bit0=None, res=None, res_p=None):
+    tester.clear()
+    tester.circuit.inst = assembler(test_op.inst)
+    tester.circuit.CLK = 0
+    data0 = BitVector[16](data0)
+    data1 = BitVector[16](data1)
+    tester.circuit.data0 = data0
+    tester.circuit.data1 = data1
+    if bit0 is not None:
+        tester.circuit.bit0 = BitVector[1](bit0)
+    tester.eval()
+    if res is not None:
+        tester.circuit.O0.expect(res)
+    if res_p is not None:
+        tester.circuit.O1.expect(res_p)
+    # detect if the PE circuit has been built
+    skip_verilator = os.path.isfile(os.path.join(test_dir, "obj_dir",
+                                                 "VWrappedPE__ALL.a"))
+    tester.compile_and_run(target="verilator",
+                           directory=test_dir,
+                           flags=['-Wno-UNUSED', '-Wno-PINNOCONNECT'],
+                           skip_compile=True,
+                           skip_verilator=skip_verilator)
+
 
 op = namedtuple("op", ["inst", "func"])
 NTESTS = 16
+
 
 def bfloat16(sign, exponent, mantissa):
     sign &= 0x1
@@ -39,6 +90,7 @@ def test_unsigned_binary(op, args):
     x, y = args
     res, _, _ = pe(op.inst, Data(x), Data(y))
     assert res==op.func(x,y)
+    rtl_tester(op, x, y, res=res)
 
 @pytest.mark.parametrize("op", [
     op(asm.lsl(),   lambda x, y: x << y),
@@ -53,6 +105,7 @@ def test_signed_binary(op, args):
     x, y = args
     res, _, _ = pe(op.inst, Data(x), Data(y))
     assert res==op.func(x,y)
+    rtl_tester(op, x, y, res=res)
 
 @pytest.mark.parametrize("op", [
     op(asm.abs(),  lambda x: x if x > 0 else -x),
@@ -63,6 +116,7 @@ def test_signed_unary(op, args):
     x = args
     res, _, _ = pe(op.inst, Data(x))
     assert res == op.func(x)
+    rtl_tester(op, x, 0, res=res)
 
 @pytest.mark.parametrize("op", [
     op(asm.eq(),   lambda x, y: x == y),
@@ -79,6 +133,7 @@ def test_unsigned_relation(op, args):
     x, y = args
     _, res_p, _ = pe(op.inst, Data(x), Data(y))
     assert res_p==op.func(x,y)
+    rtl_tester(op, x, y, res_p=res_p)
 
 @pytest.mark.parametrize("op", [
     op(asm.sgt(),  lambda x, y: x >  y),
@@ -93,6 +148,7 @@ def test_signed_relation(op, args):
     x, y = args
     _, res_p, _ = pe(op.inst, Data(x), Data(y))
     assert res_p==op.func(x,y)
+    rtl_tester(op, x, y, res_p=res_p)
 
 @pytest.mark.parametrize("args", [
     (UIntVector.random(DATAWIDTH), UIntVector.random(DATAWIDTH))  
@@ -102,8 +158,10 @@ def test_sel(args):
     x, y = args
     res, _, _ = pe(inst, Data(x), Data(y), Bit(0))
     assert res==y
+    rtl_tester(op, x, y, Bit(0), res=res)
     res, _, _ = pe(inst, Data(x), Data(y), Bit(1))
     assert res==x
+    rtl_tester(op, x, y, Bit(1), res=res)
 
 @pytest.mark.parametrize("args", [
     (SIntVector.random(DATAWIDTH), SIntVector.random(DATAWIDTH))  
@@ -119,10 +177,13 @@ def test_smult(args):
     xy = mul(x,y)
     res, _, _ = pe(smult0, Data(x), Data(y))
     assert res == xy[0:DATAWIDTH]
+    rtl_tester(smult0, x, y, res=res)
     res, _, _ = pe(smult1, Data(x), Data(y))
     assert res == xy[DATAWIDTH//2:DATAWIDTH//2+DATAWIDTH]
+    rtl_tester(smult1, x, y, res=res)
     res, _, _ = pe(smult2, Data(x), Data(y))
     assert res == xy[DATAWIDTH:]
+    rtl_tester(smult2, x, y, res=res)
 
 @pytest.mark.parametrize("args", [
     (UIntVector.random(DATAWIDTH), UIntVector.random(DATAWIDTH))  
@@ -138,15 +199,16 @@ def test_umult(args):
     xy = mul(x,y)
     res, _, _ = pe(umult0, Data(x), Data(y))
     assert res == xy[0:DATAWIDTH]
+    rtl_tester(umult0, x, y, res=res)
     res, _, _ = pe(umult1, Data(x), Data(y))
     assert res == xy[DATAWIDTH//2:DATAWIDTH//2+DATAWIDTH]
+    rtl_tester(umult1, x, y, res=res)
     res, _, _ = pe(umult2, Data(x), Data(y))
     assert res == xy[DATAWIDTH:]
+    rtl_tester(umult2, x, y, res=res)
 
 
-
-
-#TODO these tests are likely captured by the tests above. Keep them for now
+# TODO these tests are likely captured by the tests above. Keep them for now
 def test_lsl():
     pe = gen_pe(BitVector.get_family())()
     inst = asm.lsl()

--- a/tests/test_rtl.py
+++ b/tests/test_rtl.py
@@ -58,7 +58,7 @@ def wrap_with_disassembler(PE, disassembler, width, layout, inst_type):
     return WrappedPE
 
 
-@pytest.mark.parametrize('op', [add, and_, or_, xor, fp_add, fp_mult, faddiexp,
+@pytest.mark.parametrize('op', [add, fp_add, fp_mult, faddiexp,
                                 fsubexp, fcnvexp2f, fgetfint, fgetffrac])
 @pytest.mark.parametrize('mode', [Mode.BYPASS, Mode.DELAY])
 @pytest.mark.parametrize('use_assembler', [False, True])


### PR DESCRIPTION
It uses one of the new feature in fault that allows to reuse `verilator` build. It should be must faster than before. 

We still need to decide how to test the `REG_MODE`. I left one op in `test_rtl` to test the delay.