### PR TITLE
Get ready to be containerized

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,19 @@
-language: python
-addons:
-  apt:
-    packages:
-    - verilator
-before_install:
-# install conda
-- wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-- chmod +x miniconda.sh
-- ./miniconda.sh -b -p $TRAVIS_BUILD_DIR/miniconda
-- export PATH=$TRAVIS_BUILD_DIR/miniconda/bin:$PATH
-- hash -r
-- conda config --set always_yes yes --set changeps1 no
-- conda update -q conda
-- conda create -q -n test-env python=3.7
-- source activate test-env
-- conda install pip
+dist: xenial
+language: minimal
+service: docker
+
 install:
-- pip install pysmt
-- pysmt-install --z3 --confirm-agreement
-- export PYTHONPATH="/home/travis/.smt_solvers/python-bindings-3.6:${PYTHONPATH}"
-- export LD_LIBRARY_PATH="/home/travis/.smt_solvers/python-bindings-3.6:${LD_LIBRARY_PATH}"
-- pysmt-install --check
-- pip install pytest-cov
-- git clone https://github.com/phanrahan/peak.git
-- git clone -b iofix https://github.com/rdaly525/MetaMapper.git
-- pip install --ignore-installed git+git://github.com/leonardt/fault#egg=fault
-- pip install --ignore-installed git+git://github.com/phanrahan/magma#egg=magma-lang
-- pip install --ignore-installed git+git://github.com/phanrahan/mantle#egg=mantle
-- pip install -e ./peak
-- pip install -e ./MetaMapper
-- pip install -e .
+    - docker pull keyiz/garnet-flow
+    - docker run -d -it --name lassen keyiz/garnet-flow bash
+    - docker cp ../lassen lassen:/
+    - docker exec -i lassen bash -c "pip install -r /lassen/requirements.txt" 
+    - docker exec -i lassen bash -c "pip install pytest python-coveralls"
+    - docker exec -i lassen bash -c "pip install pytest-cov pytest-codestyle" 
+    # check CoSA dependencies
+    - docker exec -i lassen bash -c "pysmt-install --check"
+    - docker exec -i lassen bash -c "cd /lassen && pip install -e ." 
+
+
 script:
-- pytest -v tests/
+    - docker exec -i lassen bash -c "/lassen/.travis/run.sh"
+

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,6 @@
+# force color
+export PYTEST_ADDOPTS="--color=yes"
+
+cd /lassen
+
+pytest -v tests/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+-e git+git://github.com/phanrahan/magma#egg=magma-lang
+-e git+git://github.com/phanrahan/peak.git#egg=peak
+-e git+git://github.com/rdaly525/MetaMapper.git@iofix#egg=metamapper
+-e git+git://github.com/leonardt/fault#egg=fault
+-e git+git://github.com/phanrahan/mantle#egg=mantle
+cosa
+hwtypes


### PR DESCRIPTION
Need to be put into a container to utilize the available docker agents in buildkite. Once this is approved I will set up buildkite pipelines to run tests on floating points.

Other benefits:
- It also reduces the setup time on travis from ~2 minutes to about 30 seconds since we don't need to use miniconda anymore. 
- You can reproduce the tests locally without resorting to travis. It should 100% match with the travis result. If you have any problems setting up docker on your machine, please let me know.