### PR TITLE
Fault quiet

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -3,4 +3,4 @@ export PYTEST_ADDOPTS="--color=yes"
 
 cd /lassen
 
-pytest --cov lassen --cov-report term-missing -v --capture=sys tests/
+pytest --cov lassen --cov-report term-missing -v tests/

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 -e git+git://github.com/phanrahan/magma@sequential-async-reset#egg=magma-lang
 -e git+git://github.com/phanrahan/peak.git#egg=peak
 -e git+git://github.com/rdaly525/MetaMapper.git#egg=metamapper
--e git+git://github.com/leonardt/fault#egg=fault
+-e git+git://github.com/leonardt/fault@capture-stdout#egg=fault
 -e git+git://github.com/phanrahan/mantle#egg=mantle
 cosa
 -e git+git://github.com/leonardt/hwtypes#egg=hwtypes


### PR DESCRIPTION
Remove `--capture=sys` by using fault's `capture-stdout` branch which captures the simulator output by default (hopefully avoiding abort errors which we believe are related to pytest capturing stdout of test runs).

We can wait for fault to merge to master and update requirements.txt, or do that after pulling this in.