### PR TITLE
Highlight that Python 3.6.5 will not work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The PE for the second generation CGRA (garnet).
 
 
 ## Instructions to run
-* Make sure you have python 3.7. Peak needs this.
+* Make sure you have python 3.7. Peak needs this. Python 3.6.5 will **not** work.
 
 * First install peak
 ```


### PR DESCRIPTION
Python 3.6.5 is the default version for ubuntu 18.04, and it's a bit hard to install 3.7 and all its packages, so probably I'm not the only one who would think that 3.6.5 was close enough to 3.7 and probably it could work (which it doesn't). 
Also, the error message I got when running using 3.6.5 gives no clue that it's a python version issue at all, and it took me a long time to figure out the real cause. As such I think it would be helpful to highlight that 3.6.5 does not work.